### PR TITLE
Increase compatibility of the package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.7'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Normalization"
 uuid = "be38d6a3-8366-4a42-ad57-222272b5bbe7"
 authors = ["brendanjohnharris <brendanjohnharris@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 JuliennedArrays = "5cadff95-7770-533d-a838-a1bf817ee6e0"

--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 JuliennedArrays = "0.3, 0.4"
-julia = "1.6 - 1.8"
+julia = "1.6"


### PR DESCRIPTION
Since the package is tested on nightly, compatibility should not be restricted to 1.8, otherwise this will block downstream packages from being tested on nightly. 

I also changed the CI from 1.7 to 1, since that will automatically test on the latest release version of Julia.