### PR TITLE
docs: document MinMax behavior on constant-valued inputs; mention MinMaxClip

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Any of these normalizations will work in place of `ZScore` in the examples above
 | `HalfZScore` | $\sqrt{1-2/\pi} \cdot (x - \inf{x})/\sigma$ | Normalization to the standard half-normal distribution |
 | `OutlierSuppress` | $\max(\min(x, \mu + 5\sigma), \mu - 5\sigma)$ | Clip values outside of $\mu \pm 5\sigma$ |
 
+> **Note on `MinMax` and constant inputs**  
+> When all values are identical (`min == max`), the standard MinMax formula is undefined; `MinMax` therefore returns `NaN` values for such arrays. If you prefer a bounded fallback, use `MinMaxClip`, which maps constant inputs to the midpoint of the unit interval and clips out-of-range values to `[0, 1]`.
 
 ## Normalization modifiers
 What if the input data contains NaNs or outliers?


### PR DESCRIPTION
This PR adds a short note clarifying that `MinMax` returns NaN for constant inputs (min == max), while `MinMaxClip` provides a bounded alternative.
Context: cross-language study observed that sklearn returns zeros for constant inputs. Including the note helps users anticipate behavior and choose the appropriate transformer.

## Summary by Sourcery

Documentation:
- Clarify that MinMax returns NaN when min equals max and recommend MinMaxClip for constant-valued inputs